### PR TITLE
Improve exercise titles/descriptions

### DIFF
--- a/workshop/README.md
+++ b/workshop/README.md
@@ -2,8 +2,8 @@
 
 Welcome to our workshop! In this workshop we'll be looking at various parts of the Cloud Pak for Integration platform. The goals of this workshop are:
 
-* Leveraging **App Connect** to create a new API that syncs with Salesforce,
-* Using **API Connect** to publish our new API,
+* Create a new API that syncs with Salesforce, using **App Connect**
+* Publish your new API, Using **API Connect**
 * Producing and consuming messages with **Event Streams**.
 
 ![Cloud Pak for Integration](.gitbook/images/cp4int.png)

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -3,7 +3,7 @@
 Welcome to our workshop! In this workshop we'll be looking at various parts of the Cloud Pak for Integration platform. The goals of this workshop are:
 
 * Create a new API that syncs with Salesforce, using **App Connect**
-* Publish your new API, Using **API Connect**
+* Publish your new API, using **API Connect**
 * Producing and consuming messages with **Event Streams**.
 
 ![Cloud Pak for Integration](.gitbook/images/cp4int.png)

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -3,7 +3,7 @@
 Welcome to our workshop! In this workshop we'll be looking at various parts of the Cloud Pak for Integration platform. The goals of this workshop are:
 
 * Create a new API that syncs with Salesforce, using **App Connect**
-* Publish your new API, using **API Connect**
+* Create and publish a managed API endpoint for an existing REST service, using **API Connect**
 * Producing and consuming messages with **Event Streams**.
 
 ![Cloud Pak for Integration](.gitbook/images/cp4int.png)

--- a/workshop/SUMMARY.md
+++ b/workshop/SUMMARY.md
@@ -7,7 +7,7 @@
 ## Workshop
 
 * [Exercise: Create a new API that syncs with Salesforce, using App Connect](exercise-app-connect/README.md)
-* [Exercise: Publish your API, using API Connect](exercise-api-connect/README.md)
+* [Exercise: Create and publish a managed API endpoint for an existing REST service, using API Connect](exercise-api-connect/README.md)
 * [Exercise: Produce and consume messages with Event Streams](exercise-event-streams/README.md)
 <!-- * [Exercise: Integrate with MQ](exercise-mq/README.md) -->
 

--- a/workshop/SUMMARY.md
+++ b/workshop/SUMMARY.md
@@ -6,8 +6,8 @@
 
 ## Workshop
 
-* [Exercise: Leverage App Connect to create a new API that syncs with Salesforce](exercise-app-connect/README.md)
-* [Exercise: Use API Connect to publish your API](exercise-api-connect/README.md)
+* [Exercise: Create a new API that syncs with Salesforce, using App Connect](exercise-app-connect/README.md)
+* [Exercise: Publish your API, using API Connect](exercise-api-connect/README.md)
 * [Exercise: Produce and consume messages with Event Streams](exercise-event-streams/README.md)
 <!-- * [Exercise: Integrate with MQ](exercise-mq/README.md) -->
 

--- a/workshop/exercise-api-connect/README.md
+++ b/workshop/exercise-api-connect/README.md
@@ -1,11 +1,20 @@
-# Exercise: Publish your API, using API Connect
+# Exercise: Create and publish a managed API endpoint for an existing REST service, using API Connect
 
-In this exercise, we will show how to use API Connect to publish API.
+As you build your server applications with REST interfaces, you need to consider how these interfaces are exposed to other developers. While it is technically possible to simply give them a direct URL to the component in question, typically you will want to take a much more managed approach to formally publishing a URL endpoint. For instance, you need to consider:
+
+* How can you horizontally scale the resources running your API endpoint?
+* How can you monitor and manage the endpoint?
+* How will you enable transition to new versions of your API, deprecating old versions over time
+* How can you secure the traffic to the endpoint?
+
+While you could implement the above directly in your service along with your code, it is good practice to separate the above functionality - particularly if you have multiple services. Having a standard way of implementing the above will bring consistency to the experience received by developers using your API. This is the goal of the API Connect component of Cloud Pak for Integration.
+
+In this exercise, we will show you how to use API Connect to accomplish some of above, by creating and publishing a new, managed API endpoint for the REST service you built with App Connect in the [previous exercise](../exercise-app-connect/README.md)
 
 When you have completed this exercise, you will understand how to
 
 * Created a managed API endpoint, by importing an OpenAPI definition for an existing REST service.
-* Configured a ClientID/API Key for security set up a proxy to the existing API.
+* Publish the new API endpoint
 * Tested the API in the API Connect developer toolkit.
 
 ## Steps

--- a/workshop/exercise-api-connect/README.md
+++ b/workshop/exercise-api-connect/README.md
@@ -1,10 +1,10 @@
-# Exercise: Add an API Management point to the application
+# Exercise: Publish your API, using API Connect
 
-In this exercise, we will show how to use API Connect to create and test an API.
+In this exercise, we will show how to use API Connect to publish API.
 
 When you have completed this exercise, you will understand how to
 
-* Created an API by importing an OpenAPI definition for an existing REST service.
+* Created a managed API endpoint, by importing an OpenAPI definition for an existing REST service.
 * Configured a ClientID/API Key for security set up a proxy to the existing API.
 * Tested the API in the API Connect developer toolkit.
 

--- a/workshop/exercise-app-connect/README.md
+++ b/workshop/exercise-app-connect/README.md
@@ -1,6 +1,6 @@
-# Exercise: Use App Connect to sync Salesforce data
+# Exercise: Create a new API that syncs with Salesforce, using App Connect
 
-In this lab you will create an App Connect API to push client data to Salesforce. This will occur whenever a user interacts with the API.
+A common requirement, when developing enterprise applications, is the need to access existing data sources in other external servies, for example exchanging data with a SaaS application. A good design practice is to enable this by creating a bespoke API that provides just the specific access you need. In this lab you will create an API to push client data to Salesforce, using App Connect. This will occur whenever a user interacts with the API.
 
 ## Steps
 

--- a/workshop/exercise-app-connect/README.md
+++ b/workshop/exercise-app-connect/README.md
@@ -1,6 +1,6 @@
 # Exercise: Create a new API that syncs with Salesforce, using App Connect
 
-A common requirement, when developing enterprise applications, is the need to access existing data sources in other external servies, for example exchanging data with a SaaS application. A good design practice is to enable this by creating a bespoke API that provides just the specific access you need. In this lab you will create an API to push client data to Salesforce, using App Connect. This will occur whenever a user interacts with the API.
+A common requirement, when developing enterprise applications, is the need to access existing data sources in other external servies - for example exchanging data with a SaaS application. A good design practice is to enable this by creating a bespoke API that provides just the specific access you need. In this lab you will create an API to push client data to Salesforce, using App Connect. This will occur whenever a user interacts with the API.
 
 ## Steps
 

--- a/workshop/exercise-event-streams/README.md
+++ b/workshop/exercise-event-streams/README.md
@@ -1,4 +1,4 @@
-# Exercise: Using IBM Event Streams for near real-time data replication
+# Exercise: Provide near real-time data replication, using IBM Event Streams
 
 In this lab you will use IBM Event Streams to replicate data from a transactional database to a reporting database. The pattern used allows for seamless horizontal scaling to minimize the latency between the time the transaction is committed to the transactional database and when it is available to be queried in the reporting database. Applications connect to Event Streams topics and write to and read from them. Topics are known groupings of related data. Topics are created and configured by the Event Streams administrator.
 


### PR DESCRIPTION
Make the titles of the exercises more "use-case-specific", by leading with the purpose, rather than the product.